### PR TITLE
SAFplus services: Convert old "EO" initialization method to non-eo method

### DIFF
--- a/src/SAFplus/components/ckpt/server/clCkptMain.c
+++ b/src/SAFplus/components/ckpt/server/clCkptMain.c
@@ -160,7 +160,7 @@ ClBoolT unblockNow = CL_FALSE;
  *****************************************************************************/
 
 
-int main(int argc, char *argv[])
+ClInt32T main(ClInt32T argc, ClCharT *argv[])
 {
     SaAisErrorT rc = SA_AIS_OK;
 
@@ -220,7 +220,7 @@ void initializeAmf(void)
      */
      clEoMyEoIocPortGet(&iocPort);
 
-     clCkptLeakyBucketInitialize();
+     
         
      /* Initialize AMF client library. */
      rc = saAmfInitialize(&amfHandle, &callbacks, &gVersion);
@@ -233,6 +233,9 @@ void initializeAmf(void)
       /*
      * Initialize ckpt server.
      */
+
+     clCkptLeakyBucketInitialize();
+
      clCkptSvrInitialize();
      
 

--- a/src/SAFplus/components/event/server/clEventMain.c
+++ b/src/SAFplus/components/event/server/clEventMain.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2002-2012 OpenClovis Solutions Inc.  All Rights Reserved.
+ * Copyright (C) 2002-2013 OpenClovis Solutions Inc.  All Rights Reserved.
  *
  * This file is available  under  a  commercial  license  from  the
  * copyright  holder or the GNU General Public License Version 2.0.
@@ -24,9 +24,9 @@
 /*******************************************************************************
  * Description :
  *          This module contains all the house keeping functionality
- *          for EM - EOnization & association with CPM, debug, etc.
+ *          for EM - Non-EOnization & association with CPM, debug, etc.
  *****************************************************************************/
-
+#include <saAmf.h>
 #define __SERVER__
 #include "clCpmApi.h"
 #include "clTimerApi.h"
@@ -41,63 +41,58 @@
 #undef __CLIENT__
 #include "clEventServerFuncTable.h"
 
-static ClCpmHandleT gClEvtCpmHandle;
+static SaAmfHandleT gClEvtAmfHandle;
+
+ClBoolT unblockNow = CL_FALSE;
 
 
-ClRcT clEventTerminate(ClInvocationT invocation, const ClNameT *compName)
-{
+void clEventTerminate(SaInvocationT invocation, const SaNameT *compName);
 
-    /* No need to check error messages b/c cannot do anything about the errors anyway... am shutting down */
-    clCpmComponentUnregister(gClEvtCpmHandle, compName, NULL);
-
-    clCpmClientFinalize(gClEvtCpmHandle);
-
-    clCpmResponse(gClEvtCpmHandle, invocation, CL_OK);
-
-    return CL_OK;
-}
 
 /******************************************************************
-                    CPM Related stuff
+                    AMF Related stuff
 ******************************************************************/
 
 /*
- * Do the CPM client init/Register 
+ * Do the AMF client init/Register 
  */
 
-ClRcT clEvtCpmInit()
+ClRcT initializeAmf()
 {
-    ClNameT appName;
-    ClCpmCallbacksT callbacks;
-    ClVersionT version;
-    ClIocPortT iocPort;
-    ClRcT rc = CL_OK;
+   
+    SaNameT             appName;      
+    SaAmfCallbacksT     callbacks;
+    SaVersionT          version;
+    ClIocPortT          iocPort;
+    SaAisErrorT         rc = SA_AIS_OK;
 
-    version.releaseCode = 'B';
-    version.majorVersion = 0x1;
-    version.minorVersion = 0x1;
-
-    callbacks.appHealthCheck = NULL;
-    callbacks.appTerminate = clEventTerminate;
-    callbacks.appCSISet = NULL;
-    callbacks.appCSIRmv = NULL;
-    callbacks.appProtectionGroupTrack = NULL;
-    callbacks.appProxiedComponentInstantiate = NULL;
-    callbacks.appProxiedComponentCleanup = NULL;
+    
+    version.releaseCode  = 'B';
+    version.majorVersion = 0x01;
+    version.minorVersion = 0x01;
+    
+    callbacks.saAmfHealthcheckCallback          = NULL; /* rarely necessary because SAFplus monitors the process */
+    callbacks.saAmfComponentTerminateCallback   = clEventTerminate;
+    callbacks.saAmfCSISetCallback               = NULL;
+    callbacks.saAmfCSIRemoveCallback            = NULL;
+    callbacks.saAmfProtectionGroupTrackCallback = NULL;
+    callbacks.saAmfProxiedComponentInstantiateCallback = NULL;
+    callbacks.saAmfProxiedComponentCleanupCallback = NULL;
 
     clEoMyEoIocPortGet(&iocPort);
-
-    rc = clCpmClientInitialize(&gClEvtCpmHandle, &callbacks, &version);
-    if (CL_OK != rc)
+   
+    rc = saAmfInitialize(&gClEvtAmfHandle, &callbacks, &version);
+    if(rc != SA_AIS_OK)
     {
         clLogWrite(CL_LOG_HANDLE_APP, CL_LOG_CRITICAL, NULL,
                    CL_LOG_MESSAGE_2_LIBRARY_INIT_FAILED, "CPM Library", rc);
     }
 
-    rc = clCpmComponentNameGet(gClEvtCpmHandle, &appName);
-    rc = clCpmComponentRegister(gClEvtCpmHandle, &appName, NULL);
+    rc = saAmfComponentNameGet(gClEvtAmfHandle, &appName);
+    rc = saAmfComponentRegister(gClEvtAmfHandle, &appName, NULL);
 
     return CL_OK;
+    
 }
 
 /*****************************************************************/
@@ -111,10 +106,19 @@ ClRcT clEvtCpmInit()
  * 5. Register with CPM for component failure notification. 
  * 6. Intialize the global variable to indicate EM is done. 
  */
-
-ClRcT clEvtInitialize(ClUint32T argc, ClCharT *argv[])
+ClRcT clEvtInitialize(ClInt32T argc, ClCharT *argv[])
 {
+
     ClRcT rc = CL_OK;
+
+    rc = initializeAmf();
+    if (rc != CL_OK)
+    {
+        CL_DEBUG_PRINT(CL_DEBUG_CRITICAL,
+                       ("Event: Amf Initialization failed [0x%X]\n\r", rc));
+        CL_FUNC_EXIT();
+        return rc;
+    }
 
     CL_FUNC_ENTER();
 
@@ -198,14 +202,7 @@ ClRcT clEvtInitialize(ClUint32T argc, ClCharT *argv[])
      * CPM should be notified that Event Service is ready only after the
      * the initialization is complete. This _MUST_ be the last step.
      */
-    rc = clEvtCpmInit();
-    if (rc != CL_OK)
-    {
-        CL_DEBUG_PRINT(CL_DEBUG_CRITICAL,
-                       ("Event: CPM Initialization failed [0x%X]\n\r", rc));
-        CL_FUNC_EXIT();
-        return rc;
-    }
+    
 
     CL_FUNC_EXIT();
     return CL_OK;
@@ -220,6 +217,7 @@ ClRcT clEvtInitialize(ClUint32T argc, ClCharT *argv[])
  * 3. Deregister with CKPT
  * 4. Release the resources like Handle Databases, etc.
  */
+
 ClRcT clEvtFinalize()
 {
     ClRcT rc = CL_OK;
@@ -237,6 +235,8 @@ ClRcT clEvtFinalize()
         CL_FUNC_EXIT();
         return rc;
     }
+    
+        
 
     rc = clEventDebugDeregister(gEvtHead.evtEOId);
     if (rc != CL_OK)
@@ -246,6 +246,8 @@ ClRcT clEvtFinalize()
         CL_FUNC_EXIT();
         return rc;
     }
+    
+    
 
     /*
      ** Handle Database Cleanup.
@@ -278,22 +280,31 @@ ClRcT clEvtFinalize()
     return CL_OK;
 }
 
+
+
+
+
+
+void clEventTerminate(SaInvocationT invocation, const SaNameT *compName)
+{
+     
+    
+
+    clEvtFinalize();
+      
+   /* No need to check error messages b/c cannot do anything about the errors anyway... am shutting down */
+
+    saAmfComponentUnregister(gClEvtAmfHandle, compName, NULL);
+
+    
+
+
+    saAmfResponse(gClEvtAmfHandle, invocation, SA_AIS_OK);
+
+    unblockNow = CL_TRUE;
+}
+
 /*****************************************************************************/
-
-
-
-ClRcT clEventStateChange(ClEoStateT eoState)
-{
-    return CL_OK;
-}
-
-ClRcT clEventHealthCheck(ClEoSchedFeedBackT *schFeedback)
-{
-    schFeedback->freq = CL_EO_DEFAULT_POLL;
-    schFeedback->status = 0;
-    return CL_OK;
-}
-
 ClEoConfigT clEoConfig = {
     1,                          /* EO Thread Priority */
     1,                          /* No of EO thread needed */
@@ -301,13 +312,13 @@ ClEoConfigT clEoConfig = {
     CL_EO_USER_CLIENT_ID_START,
     CL_EO_USE_THREAD_FOR_RECV,  /* Whether to use main thread for eo Recv or
                                  * not */
-    clEvtInitialize,            /* Function CallBack to initialize the
+    NULL,                       /* Function CallBack to initialize the
                                  * Application */
-    clEvtFinalize,              /* Function Callback to Terminate the
+    NULL,                       /* Function Callback to Terminate the
                                  * Application */
-    clEventStateChange,         /* Function Callback to change the Application
+    NULL,                       /* Function Callback to change the Application
                                  * state */
-    clEventHealthCheck,         /* Function Callback to change the Application
+    NULL,                       /* Function Callback to change the Application
                                  * state */
     NULL,
     .needSerialization = CL_TRUE
@@ -344,12 +355,90 @@ ClUint8T clEoClientLibs[] = {
     CL_FALSE,                    /* pm */
 };
 
+
+void dispatchLoop(void);
+int  errorExit(SaAisErrorT rc);
+
+/******************************************************************************
+ * Service Life Cycle Management Functions
+ *****************************************************************************/
+
+
 ClInt32T main(ClInt32T argc, ClCharT *argv[])
 {
     ClRcT rc = CL_OK;
 
     clAppConfigure(&clEoConfig,clEoBasicLibs,clEoClientLibs);
-    rc = clEoInitialize(argc, argv);
-
-    return (CL_OK != rc);
+    
+    rc = clEvtInitialize(argc,argv);
+    if( rc != CL_OK )
+    {
+        CL_DEBUG_PRINT(CL_DEBUG_CRITICAL,
+                       ("Event: clEvtInitialize failed [0x%X]\n\r", rc));
+        return rc;
+    }
+            
+    /* Block on AMF dispatch file descriptor for callbacks.
+       When this function returns its time to quit. */
+    dispatchLoop();
+    
+    /* Do the Event Service finalization here. */
+    
+   saAmfFinalize(gClEvtAmfHandle);
+     
+   return 0;
 }
+
+
+
+
+
+
+int errorExit(SaAisErrorT rc)
+{        
+  
+    exit(-1);
+    return -1;
+}
+
+
+
+void dispatchLoop(void)
+{        
+  SaAisErrorT         rc = SA_AIS_OK;
+  SaSelectionObjectT amf_dispatch_fd;
+  int maxFd;
+  fd_set read_fds;
+
+  /*
+   * Get the AMF dispatch FD for the callbacks
+   */
+  if ( (rc = saAmfSelectionObjectGet(gClEvtAmfHandle, &amf_dispatch_fd)) != SA_AIS_OK)
+    errorExit(rc);
+      
+  maxFd = amf_dispatch_fd;  
+  do
+    {
+      FD_ZERO(&read_fds);
+      FD_SET(amf_dispatch_fd, &read_fds);
+      if( select(maxFd + 1, &read_fds, NULL, NULL, NULL) < 0)
+      {
+          char errorStr[80];
+          int err = errno;
+          if (EINTR == err) continue;
+
+          errorStr[0] = 0; /* just in case strerror does not fill it in */
+          strerror_r(err, errorStr, 79);
+         
+          break;
+        }
+      if (FD_ISSET(amf_dispatch_fd,&read_fds)) saAmfDispatch(gClEvtAmfHandle, SA_DISPATCH_ALL);
+      
+    }while(!unblockNow);      
+}
+
+
+
+
+
+

--- a/src/SAFplus/components/gms/server/clGmsEo.c
+++ b/src/SAFplus/components/gms/server/clGmsEo.c
@@ -27,7 +27,7 @@
  * This file implements the standard NON-EO template functions 
  * and data structures for GMS.
  *******************************************************************************/
-
+#include <saAmf.h>
 #define __SERVER__
 #include <stdio.h>
 #include <unistd.h>
@@ -146,10 +146,9 @@ ClBoolT unblockNow = CL_FALSE;
  * Application Life Cycle Management Functions
  *****************************************************************************/
 
-
-int main(int argc, char *argv[])
+ClInt32T main(ClInt32T argc, ClCharT *argv[])
 {
-    ClRcT   rc = CL_OK;
+    
     if (argc < 2){
         clLog (EMER,GEN,NA, "usage : %s", GMS_USAGE);
         exit(0);
@@ -165,13 +164,13 @@ int main(int argc, char *argv[])
        When this function returns its time to quit. */
     dispatchLoop();
     
-    rc = clHandleDatabaseDestroy(contextHandleDatabase);
-    if (rc != CL_OK)
-    {
-        clLog(ERROR,GEN,NA,
-                "contextHandleDatabase destroy failed with Rc = 0x%x",rc);
-    }
+    
+     
+    
+     saAmfFinalize(amfHandle);
 
+    
+    
     return 0;
 }
 /*
@@ -233,21 +232,9 @@ void clGmsServerTerminate(SaInvocationT invocation, const SaNameT *compName)
      * Unregister with AMF and respond to AMF saying whether the
      * termination was successful or not.
      */
-    rc = saAmfComponentUnregister(amfHandle, compName, NULL);
     
-    if(rc != SA_AIS_OK) 
-    {
-        clLog(ERROR,GEN,NA,
-              "saAmfComponentUnregister failed with rc = 0x%x", rc);     
-    }
 
-    rc = saAmfFinalize(amfHandle);
-
-    if (rc != SA_AIS_OK)
-    {
-        clLog(ERROR,GEN,NA,
-              "saAmfFinalize failed with rc = 0x%x", rc);
-    }
+    
 
     rc1 = clDebugDeregister(gGmsDebugReg);
     if (rc1 != CL_OK)
@@ -257,13 +244,7 @@ void clGmsServerTerminate(SaInvocationT invocation, const SaNameT *compName)
     }
 
     /* Ok tell SAFplus that we handled it properly */
-    rc = saAmfResponse(amfHandle, invocation, SA_AIS_OK);
     
-    if (rc != SA_AIS_OK)
-    {
-        clLog(ERROR,GEN,NA,
-              "clCpmResponse failed with rc = 0x%x", rc);
-    }
     /* Close the leader election algorithm dl if open */
 #ifndef VXWORKS_BUILD 
     if (pluginHandle != NULL)
@@ -283,6 +264,29 @@ void clGmsServerTerminate(SaInvocationT invocation, const SaNameT *compName)
     }
     clLog(CRITICAL,GEN,NA,
           "GMS server exiting");
+    rc = clHandleDatabaseDestroy(contextHandleDatabase);
+    if (rc != CL_OK)
+    {
+        clLog(ERROR,GEN,NA,
+                "contextHandleDatabase destroy failed with Rc = 0x%x",rc);
+    }
+    
+    rc = saAmfComponentUnregister(amfHandle, compName, NULL);
+    
+    if(rc != SA_AIS_OK) 
+    {
+        clLog(ERROR,GEN,NA,
+              "saAmfComponentUnregister failed with rc = 0x%x", rc);     
+    }
+    
+    rc = saAmfResponse(amfHandle, invocation, SA_AIS_OK);
+    
+    if (rc != SA_AIS_OK)
+    {
+        clLog(ERROR,GEN,NA,
+              "saAMfResponse failed with rc = 0x%x", rc);
+    }
+
     
     unblockNow = CL_TRUE;
 }
@@ -397,7 +401,7 @@ void initializeAmf(void)
 
     /* This function never returns the exit is done by causing a signal from
      *  the Terminate function */
-    _initializeamf();
+   
     
 }
 

--- a/src/SAFplus/components/log/server/clLogSvrMain.c
+++ b/src/SAFplus/components/log/server/clLogSvrMain.c
@@ -95,14 +95,11 @@ int  errorExit(SaAisErrorT rc);
 
 ClBoolT unblockNow = CL_FALSE;
 
-int main(int argc, char *argv[])
+ClInt32T main(ClInt32T argc, ClCharT *argv[])
 {
     ClRcT            rc            = CL_OK;
    
-    clLogInfo("HM", "MIND", "ENTER INTO THE LOG SERVICE FOR CLAPP");
-    
-     
-    
+       
 
     rc = clLogSvrInitialize(argc,argv);
     if(rc != CL_OK)
@@ -153,6 +150,13 @@ clLogSvrInitialize(ClUint32T argc,ClCharT   *argv[])
     if( SA_AIS_OK != rc1 )
     {
         CL_LOG_DEBUG_ERROR(("saAmfInitialize(): rc[0x %x]", rc1));
+        CL_LOG_CLEANUP(clLogSvrEoDataFinalize(), CL_OK);
+        CL_LOG_CLEANUP(clLogSvrEoDataFree(), CL_OK);
+        clHeapFree(pCookie);
+        CL_LOG_CLEANUP(clLogStreamOwnerLocalShutdown(), CL_OK);
+        CL_LOG_CLEANUP(clLogStreamOwnerEoDataFree(), CL_OK);
+        CL_LOG_CLEANUP(clLogSvrCommonDataFinalize(), CL_OK);
+        CL_LOG_CLEANUP(clIdlHandleFinalize(shLogDummyIdl), CL_OK);
         rc = (ClRcT)rc1;
         return rc;
     }

--- a/src/SAFplus/components/msg/server/clMsgEo.c
+++ b/src/SAFplus/components/msg/server/clMsgEo.c
@@ -29,6 +29,9 @@
 
 
 /*#include <arpa/inet.h>*/
+/******************************************************************************
+ * Include files needed to compile this file
+ *****************************************************************************/
 
 #include <clCommon.h>
 #include <clCommonErrors.h>
@@ -54,10 +57,46 @@
 #include <msgCltSrvServer.h>
 #include <msgCltSrvClient.h>
 
-ClCpmHandleT cpmHandle;
+/* POSIX Includes */
+#include <assert.h>
+#include <errno.h>
 
-static ClRcT clMsgInitialize(ClUint32T argc, ClCharT *argv[]);
-static ClRcT clMsgFinalize(ClBoolT *pLockStatus);
+/* Basic SAFplus Includes */
+#include <clCommon.h>
+
+/* SAFplus Client Includes */
+#include <clLogApi.h>
+#include <clCpmApi.h>
+#include <saAmf.h>
+
+
+#define clprintf(severity, ...)   clAppLog(CL_LOG_HANDLE_APP, severity, 10, "MAI", CL_LOG_CONTEXT_UNSPECIFIED,__VA_ARGS__)
+/* Global Declarations */
+SaAmfHandleT amfHandle;
+
+ClBoolT unblockNow = CL_FALSE;
+
+SaNameT      appName = {0};
+
+int errorExit(SaAisErrorT rc)
+{        
+    exit(-1);
+    return -1;
+}
+
+/* Function Declarations */
+static int initializeAmf(void);
+static ClHandleT gMsgNotificationHandle;
+ClInt32T gClMsgSvcRefCnt;
+ClHandleDatabaseHandleT gMsgClientHandleDb;
+ClOsalMutexT gClMsgFinalizeLock;
+ClOsalCondT  gClMsgFinalizeCond;
+static void safTerminate(SaInvocationT invocation, const SaNameT *compName);
+static void clMsgRegisterWithCpm(void);
+static void clMsgNotificationReceiveCallback(ClIocNotificationIdT event, ClPtrT pArg, ClIocAddressT *pAddr);
+static void *clMsgCachedCkptInitAsync(void *pParam);
+static int safMsgFinalize(ClBoolT *pLockStatus);
+static void dispatchLoop(void);
 
 ClEoConfigT clEoConfig = {
     1,                              /* EO Thread Priority */
@@ -65,7 +104,7 @@ ClEoConfigT clEoConfig = {
     CL_IOC_MSG_PORT,                /* Required Ioc Port */
     CL_EO_USER_CLIENT_ID_START,
     CL_EO_USE_THREAD_FOR_RECV,      /* Whether to use main thread for eo Recv or not */
-    clMsgInitialize,                /* Function CallBack to initialize the Application */
+    NULL,                           /* Function CallBack to initialize the Application */
     NULL,                           /* Function Callback to Terminate the Application */
     NULL /*clMsgStateChange*/,      /* Function Callback to change the Application state */
     NULL /*clMsgHealthCheck*/,      /* Function Callback to check the Application health */
@@ -104,165 +143,57 @@ ClUint8T clEoClientLibs[] = {
     CL_FALSE,                   /* pm */
 };
 
+
 ClInt32T main(ClInt32T argc, ClCharT *argv[])
 {
-    ClRcT rc = CL_OK;
 
-    clAppConfigure(&clEoConfig,clEoBasicLibs,clEoClientLibs);
-    rc = clEoInitialize(argc, argv);
+	SaAisErrorT rc = SA_AIS_OK;
 
-    return (CL_OK != rc);
-}
-
-
-static ClHandleT gMsgNotificationHandle;
-ClInt32T gClMsgSvcRefCnt;
-ClHandleDatabaseHandleT gMsgClientHandleDb;
-ClOsalMutexT gClMsgFinalizeLock;
-ClOsalCondT  gClMsgFinalizeCond;
-
-static ClRcT clMsgTerminate(ClInvocationT invocation,
-                            const ClNameT *compName)
-{
-    if(gClMsgInit)
-    {
-        ClBoolT lockStatus = CL_TRUE;
-        ClTimerTimeOutT timeout = {.tsSec = 0, .tsMilliSec = 0};
-        clOsalMutexLock(&gClMsgFinalizeLock);
-        while(gClMsgSvcRefCnt > 0)
-        {
-            clOsalCondWait(&gClMsgFinalizeCond, &gClMsgFinalizeLock, timeout);
-        }
-        clMsgFinalize(&lockStatus);
-        if(lockStatus)
-        {
-            clOsalMutexUnlock(&gClMsgFinalizeLock);
-        }
-    }
-    clCpmComponentUnregister(cpmHandle, compName, NULL);
-    clCpmClientFinalize(cpmHandle);
-    clCpmResponse(cpmHandle, invocation, CL_OK);
     
-    return CL_OK;
+       /* Connect to the SAF cluster */
+        
+        initializeAmf();
+        
+        /* Do the application specific initialization here. */
+    
+        /* Block on AMF dispatch file descriptor for callbacks.
+         When this function returns its time to quit. */
+	dispatchLoop();
+
+	/* Now finalize my connection with the SAF cluster */
+	rc = saAmfFinalize(amfHandle);
+	return 0;
 }
 
-
-static void clMsgRegisterWithCpm(void)
+static int initializeAmf(void)
 {
-    ClRcT rc;
-    ClNameT            appName = {0};
-    ClCpmCallbacksT    callbacks = {0};
-    ClVersionT  version = {0};
-
-    version.releaseCode = 'B';
-    version.majorVersion = 0x01;
-    version.minorVersion = 0x01;
-                                                                                                                             
-    callbacks.appHealthCheck = NULL;
-    callbacks.appTerminate = clMsgTerminate;
-    callbacks.appCSISet = NULL;
-    callbacks.appCSIRmv = NULL;
-    callbacks.appProtectionGroupTrack = NULL;
-    callbacks.appProxiedComponentInstantiate = NULL;
-    callbacks.appProxiedComponentCleanup = NULL;
-
-    rc = clCpmClientInitialize(&cpmHandle, &callbacks, &version);
-    CL_ASSERT(rc == CL_OK);
-
-    rc = clCpmComponentNameGet(cpmHandle, &appName);
-    CL_ASSERT(rc == CL_OK);
-
-    rc = clCpmComponentRegister(cpmHandle, &appName, NULL);
-    CL_ASSERT(rc == CL_OK);
-}
-
-
-static void clMsgNotificationReceiveCallback(ClIocNotificationIdT event, ClPtrT pArg, ClIocAddressT *pAddr)
-{
-    clOsalMutexLock(&gClMsgFinalizeLock);
-    if(!gClMsgInit)
-    {
-        /*
-         * Msg server already finalized. skip it.
-         */
-        clOsalMutexUnlock(&gClMsgFinalizeLock);
-        return;
-    }
-    ++gClMsgSvcRefCnt;
-    clOsalMutexUnlock(&gClMsgFinalizeLock);
-
-    if((event == CL_IOC_COMP_DEATH_NOTIFICATION && pAddr->iocPhyAddress.portId == CL_IOC_MSG_PORT) ||
-       event == CL_IOC_NODE_LEAVE_NOTIFICATION || 
-       event == CL_IOC_NODE_LINK_DOWN_NOTIFICATION)
-    {
-        clMsgNodeLeftCleanup(pAddr);
-    }
-    else if(event == CL_IOC_COMP_DEATH_NOTIFICATION)
-    {
-        clMsgCompLeftCleanup(pAddr);
-    }
-
-    clOsalMutexLock(&gClMsgFinalizeLock);
-    --gClMsgSvcRefCnt;
-    clOsalCondSignal(&gClMsgFinalizeCond);
-    clOsalMutexUnlock(&gClMsgFinalizeLock);
-
-    return;
-}
-
-static void *clMsgCachedCkptInitAsync(void *pParam)
-{
-    ClRcT rc, retCode;
-    /* Initialize cached ckpt for MSG queue & MSG queue group */
-    rc = clMsgQCkptInitialize();
-    if(rc != CL_OK)
-    {
-        clLogError("MSG", "INI", "Failed to initialize cached checkpoints. error code [0x%x].", rc);
-        goto error_out;
-    }
-
-    rc = clMsgQCkptSynch();
-    if(rc != CL_OK)
-    {
-        clLogError("MSG", "INI", "Failed to synchronize cached checkpoints. error code [0x%x].", rc);
-        goto error_out_1;
-    }
-
-    gClMsgInit = CL_TRUE;
-
-    return NULL;
-error_out_1:
-    retCode = clMsgQCkptFinalize();
-    if(retCode != CL_OK)
-        clLogError("MSG", "INI", "clMsgQCkptFinalize(): error code [0x%x].", retCode);
-error_out:
-    return NULL;
-}
-
-static ClRcT clMsgInitialize(ClUint32T argc, ClCharT *argv[])
-{
-    ClRcT rc, retCode;
+    SaAisErrorT         rc = SA_AIS_OK; 
+    SaAisErrorT         retCode;
     ClIocPhysicalAddressT notificationForComp = { CL_IOC_BROADCAST_ADDRESS, 0};
-
-    /* Checking if message service is already initialized */
+    
+    clAppConfigure(&clEoConfig,clEoBasicLibs,clEoClientLibs);
+  
+    clMsgRegisterWithCpm();
+     
     if(gClMsgInit == CL_TRUE)
     {
         rc = CL_MSG_RC(CL_ERR_INITIALIZED);
         clLogError("MSG", "INI", "The Message Service is already initialized. error code [0x%x].", rc);
         goto error_out;
     }
-
+    clprintf (CL_LOG_SEV_INFO, "Happiest Minds Message Service not Intantiated");
     gLocalAddress = clIocLocalAddressGet();
     gLocalPortId = CL_IOC_MSG_PORT;
 
     /* Initializing a database to maintain client information */
     rc = clHandleDatabaseCreate((void (*)(void*))NULL, &gMsgClientHandleDb);
+     
     if(rc != CL_OK)
     {
         clLogError("MSG", "INI", "Failed to initialize the handle database. error code [0x%x].", rc);
         goto error_out;
     }
-
+    
     /* Initializing IDL for server to server and server to client communication. */
     rc = clMsgCommIdlInitialize();
     if(rc != CL_OK)
@@ -270,7 +201,7 @@ static ClRcT clMsgInitialize(ClUint32T argc, ClCharT *argv[])
         clLogError("MSG", "INI", "Failed to initialize the IDL. error code [0x%x].", rc);
         goto error_out_2;
     }
-
+    
     /* Initializing a database for maintaining queues. */
     rc = clMsgQueueInitialize();
     if(rc != CL_OK)
@@ -278,7 +209,7 @@ static ClRcT clMsgInitialize(ClUint32T argc, ClCharT *argv[])
         clLogError("MSG", "INI", "Failed to initialize the queue databases. error code [0x%x].", rc);
         goto error_out_3;
     }
-
+   
     rc = clMsgReceiverDatabaseInit();
     if(rc != CL_OK)
     {
@@ -288,7 +219,7 @@ static ClRcT clMsgInitialize(ClUint32T argc, ClCharT *argv[])
 
     rc = clOsalMutexInit(&gClMsgFinalizeLock);
     CL_ASSERT(rc == CL_OK);
-
+    
     rc = clOsalCondInit(&gClMsgFinalizeCond);
     CL_ASSERT(rc == CL_OK);
 
@@ -302,7 +233,7 @@ static ClRcT clMsgInitialize(ClUint32T argc, ClCharT *argv[])
         clLogError("MSG", "INI", "Failed to install the notification callback function. error code [0x%x].", rc);
         goto error_out_5;
     }
-
+   
     /* Initializing the IDL generated code. */
     rc = clMsgIdlClientInstall();
     if(rc != CL_OK)
@@ -331,7 +262,7 @@ static ClRcT clMsgInitialize(ClUint32T argc, ClCharT *argv[])
         clLogError("MSG", "INI", "Failed to install Client Server Table. error code [0x%x].", rc);
         goto error_out_9;
     }
-
+  
     rc = clMsgCltSrvClientTableRegister(CL_IOC_MSG_PORT);
     if(rc != CL_OK)
     {
@@ -345,17 +276,14 @@ static ClRcT clMsgInitialize(ClUint32T argc, ClCharT *argv[])
         clLogError("MSG", "INI", "Failed to initialize the msg-finalize blocker. error code [0x%x].", rc);
         goto error_out_11;
     }
-
+   
     clMsgDebugCliRegister();
-
-    clMsgRegisterWithCpm();
 
     rc = clOsalTaskCreateDetached("MsgCkptInitAsync", CL_OSAL_SCHED_OTHER, CL_OSAL_THREAD_PRI_NOT_APPLICABLE, 0,
                                  clMsgCachedCkptInitAsync, NULL);
     CL_ASSERT(rc == CL_OK);
 
     goto out;
-
 error_out_11:
     retCode = clMsgCltSrvClientTableDeregister();
     if(retCode != CL_OK)
@@ -407,15 +335,134 @@ error_out_2:
         clLogError("MSG", "INI", "Failed to destroy the handle database. error code [0x%x].", retCode);
 error_out:
 out:
-    return rc;
+    return rc;  
+    
+}//end of intializeAmf
+
+static void safTerminate(SaInvocationT invocation, const SaNameT *compName)
+{
+    SaAisErrorT rc = SA_AIS_OK;
+    if(gClMsgInit)
+    {
+        ClBoolT lockStatus = CL_TRUE;
+        ClTimerTimeOutT timeout = {.tsSec = 0, .tsMilliSec = 0};
+        clOsalMutexLock(&gClMsgFinalizeLock);
+        while(gClMsgSvcRefCnt > 0)
+        {
+            clOsalCondWait(&gClMsgFinalizeCond, &gClMsgFinalizeLock, timeout);
+        }
+        safMsgFinalize(&lockStatus);
+        if(lockStatus)
+        {
+            clOsalMutexUnlock(&gClMsgFinalizeLock);
+        }
+    }
+    rc = saAmfComponentUnregister(amfHandle, compName, NULL);
+    clCpmClientFinalize(amfHandle);
+    //clCpmResponse(cpmHandle, invocation, CL_OK);
+    saAmfResponse(amfHandle, invocation, SA_AIS_OK);
+    
+    return;
 }
+
+
+static void clMsgRegisterWithCpm(void)
+{
+    SaAisErrorT rc = SA_AIS_OK;
+    SaAmfCallbacksT    callbacks = {0};
+    SaVersionT  version = {0};
+
+    version.releaseCode = 'B';
+    version.majorVersion = 0x01;
+    version.minorVersion = 0x01;
+                                                                                                                             
+    callbacks.saAmfHealthcheckCallback = NULL;
+    callbacks.saAmfComponentTerminateCallback = safTerminate;
+    callbacks.saAmfCSISetCallback = NULL;
+    callbacks.saAmfCSIRemoveCallback = NULL;
+    callbacks.saAmfProtectionGroupTrackCallback = NULL;
+    //callbacks.appProxiedComponentInstantiate = NULL;
+    //callbacks.appProxiedComponentCleanup = NULL;
+
+    rc = saAmfInitialize(&amfHandle, &callbacks, &version);
+
+    rc = saAmfComponentNameGet(amfHandle, &appName);
+
+    rc = saAmfComponentRegister(amfHandle, &appName, NULL);
+}
+
+
+static void clMsgNotificationReceiveCallback(ClIocNotificationIdT event, ClPtrT pArg, ClIocAddressT *pAddr)
+{
+    //SaAisErrorT rc = SA_AIS_OK;
+    clOsalMutexLock(&gClMsgFinalizeLock);
+    if(!gClMsgInit)
+    {
+        /*
+         * Msg server already finalized. skip it.
+         */
+        clOsalMutexUnlock(&gClMsgFinalizeLock);
+        return;
+    }
+    ++gClMsgSvcRefCnt;
+    clOsalMutexUnlock(&gClMsgFinalizeLock);
+
+    if((event == CL_IOC_COMP_DEATH_NOTIFICATION && pAddr->iocPhyAddress.portId == CL_IOC_MSG_PORT) ||
+       event == CL_IOC_NODE_LEAVE_NOTIFICATION || 
+       event == CL_IOC_NODE_LINK_DOWN_NOTIFICATION)
+    {
+        clMsgNodeLeftCleanup(pAddr);
+    }
+    else if(event == CL_IOC_COMP_DEATH_NOTIFICATION)
+    {
+        clMsgCompLeftCleanup(pAddr);
+    }
+
+    clOsalMutexLock(&gClMsgFinalizeLock);
+    --gClMsgSvcRefCnt;
+    clOsalCondSignal(&gClMsgFinalizeCond);
+    clOsalMutexUnlock(&gClMsgFinalizeLock);
+
+    return;
+}
+
+static void *clMsgCachedCkptInitAsync(void *pParam)
+{
+    SaAisErrorT rc = SA_AIS_OK;
+    SaAisErrorT retCode;
+    /* Initialize cached ckpt for MSG queue & MSG queue group */
+    rc = clMsgQCkptInitialize();
+    if(rc != CL_OK)
+    {
+        clLogError("MSG", "INI", "Failed to initialize cached checkpoints. error code [0x%x].", rc);
+        goto error_out;
+    }
+
+    rc = clMsgQCkptSynch();
+    if(rc != CL_OK)
+    {
+        clLogError("MSG", "INI", "Failed to synchronize cached checkpoints. error code [0x%x].", rc);
+        goto error_out_1;
+    }
+
+    gClMsgInit = CL_TRUE;
+
+    return NULL;
+error_out_1:
+    retCode = clMsgQCkptFinalize();
+    if(retCode != CL_OK)
+        clLogError("MSG", "INI", "clMsgQCkptFinalize(): error code [0x%x].", retCode);
+error_out:
+    return NULL;
+}
+
 
 /*
  * Called with the msg finalize lock held.
  */
-static ClRcT clMsgFinalize(ClBoolT *pLockStatus)
+static int safMsgFinalize(ClBoolT *pLockStatus)
 {
-    ClRcT rc = CL_OK;
+    SaAisErrorT rc = SA_AIS_OK;
     if(pLockStatus && !*pLockStatus) 
         return CL_MSG_RC(CL_ERR_INVALID_STATE);
 
@@ -484,5 +531,50 @@ static ClRcT clMsgFinalize(ClBoolT *pLockStatus)
 
 out:
     return rc;
+}
+
+
+/* dispatch loop  */
+void dispatchLoop(void)
+{        
+  SaAisErrorT         rc = SA_AIS_OK;
+  SaSelectionObjectT amf_dispatch_fd;
+  int maxFd;
+  fd_set read_fds;
+
+  /* This boilerplate code includes an example of how to simultaneously
+     dispatch for 2 services (in this case AMF and CKPT).  But since checkpoint
+     is not initialized or used, it is commented out */
+  /* SaSelectionObjectT ckpt_dispatch_fd; */
+
+  /*
+   * Get the AMF dispatch FD for the callbacks
+   */
+  if ( (rc = saAmfSelectionObjectGet(amfHandle, &amf_dispatch_fd)) != SA_AIS_OK)
+    errorExit(rc);
+  /* if ( (rc = saCkptSelectionObjectGet(ckptLibraryHandle, &ckpt_dispatch_fd)) != SA_AIS_OK)
+       errorExit(rc); */
+    
+  maxFd = amf_dispatch_fd;  /* maxFd = max(amf_dispatch_fd,ckpt_dispatch_fd); */
+  do
+    {
+      FD_ZERO(&read_fds);
+      FD_SET(amf_dispatch_fd, &read_fds);
+      /* FD_SET(ckpt_dispatch_fd, &read_fds); */
+        
+      if( select(maxFd + 1, &read_fds, NULL, NULL, NULL) < 0)
+        {
+          char errorStr[80];
+          int err = errno;
+          if (EINTR == err) continue;
+
+          errorStr[0] = 0; /* just in case strerror does not fill it in */
+          strerror_r(err, errorStr, 79);
+          clprintf (CL_LOG_SEV_ERROR, "Error [%d] during dispatch loop select() call: [%s]",err,errorStr);
+          break;
+        }
+      if (FD_ISSET(amf_dispatch_fd,&read_fds)) saAmfDispatch(amfHandle, SA_DISPATCH_ALL);
+      /* if (FD_ISSET(ckpt_dispatch_fd,&read_fds)) saCkptDispatch(ckptLibraryHandle, SA_DISPATCH_ALL); */
+    }while(!unblockNow);      
 }
 

--- a/src/SAFplus/components/name/server/clNameMain.c
+++ b/src/SAFplus/components/name/server/clNameMain.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2002-2012 OpenClovis Solutions Inc.  All Rights Reserved.
+ * Copyright (C) 2002-2013 OpenClovis Solutions Inc.  All Rights Reserved.
  *
  * This file is available  under  a  commercial  license  from  the
  * copyright  holder or the GNU General Public License Version 2.0.
@@ -28,6 +28,11 @@ File        : clNameMain.c
  *
  *
  *****************************************************************************/
+#include <saAmf.h>
+
+
+
+
 
 #define __SERVER__
 #include "stdio.h"
@@ -100,7 +105,7 @@ static ClUint32T         sNoUserGlobalCxt = 0;
 static ClUint32T         sNoUserLocalCxt  = 0;
 static ClUint64T         sObjCount        = CL_IOC_DYNAMIC_LOGICAL_ADDRESS_START;
 ClCpmHandleT    	     cpmHandle        = 0;
-
+SaAmfHandleT                 amfHandle;
 ClCntHandleT           gNSDefaultGlobalHashTable    = 0;
 ClCntHandleT           gNSDefaultNLHashTable        = 0;
 ClCntHandleT           gNSHashTable                 = 0;
@@ -115,6 +120,7 @@ static ClVersionT      gNSServerToServerVersionSupported[]={
 {'B',0x01 , 0x01}
 };
 
+ClBoolT unblockNow = CL_FALSE;
 
 extern ClCkptSvcHdlT   gNsCkptSvcHdl ;
 static ClNameSvcConfigT gpConfig = {0};
@@ -180,11 +186,13 @@ clNSLookupKeyForm(ClNameT               *pName,
 /******************** Functions needed by EO infrastructure **************/
 /*************************************************************************/
 
-ClRcT   nameSvcFinalize(ClInvocationT invocation,
-    		const ClNameT  *compName)
+void nameSvcFinalize(SaInvocationT invocation, const SaNameT *compName)
 {
-    ClRcT             rc      = CL_OK;
+    
     ClEoExecutionObjT *pEOObj = NULL;
+
+
+    
 
     /* take the semaphore */
     if(clOsalMutexLock(gSem)  != CL_OK)
@@ -192,19 +200,26 @@ ClRcT   nameSvcFinalize(ClInvocationT invocation,
         CL_DEBUG_PRINT(CL_DEBUG_ERROR, ("\n NS: Couldnt get Lock successfully--\n"));
     }
     
+   
+
     /* Do NS related cleanup */
 
     /* Delete all the entries in all the contexts */
     /* Delete all the per context has tables */
     clCntWalk(gNSHashTable, _nameSvcContextLevelWalkForFinalize, NULL, 0);
+    
     clCntDelete(gNSHashTable);
+    
     gNSHashTable = 0;
     /* Finalize ckpt lib */    
     clNameSvcCkptFinalize();
+    
     clHeapFree(gpContextIdArray);
+    
     clHeapFree(gNSClientToServerVersionInfo.versionsSupported);
+   
     clHeapFree(gNSServerToServerVersionInfo.versionsSupported);
-
+   
     /* Release the semaphore */
     clOsalMutexUnlock(gSem);
     
@@ -213,31 +228,53 @@ ClRcT   nameSvcFinalize(ClInvocationT invocation,
     (void)clEoClientUninstallTables(pEOObj, CL_EO_SERVER_SYM_MOD(gAspFuncTable, NAM));
     /* Finalize event lib */
     (void)nameSvcEventFinalize();
-
+    
     /* DeRegister with debug infra */
     (void)nameDebugDeregister(pEOObj);
-
-    rc = clCpmComponentUnregister(cpmHandle, compName, NULL);
-    rc = clCpmClientFinalize(cpmHandle);
-
-    clLogNotice("SVR", "SHU", "Name service has been finalized successfully");
-    clCpmResponse(cpmHandle, invocation, CL_OK);
-
-    return CL_OK;
+    
+    saAmfComponentUnregister(amfHandle, compName, NULL);
+    
+    saAmfResponse(amfHandle, invocation, CL_OK);
+    
+    unblockNow = CL_TRUE;
+    
 }
 
 
 ClRcT   nameSvcInitialize(ClUint32T argc, ClCharT *argv[])
 {
-    ClNameT           appName   = {0};
-    ClCpmCallbacksT   callbacks = {0};
-    ClVersionT	      version   = {0};
+    SaNameT           appName   = {0};
+    SaAmfCallbacksT   callbacks = {0};
+    SaVersionT	      version   = {0};
     ClIocPortT	      iocPort   = 0;
     ClRcT             rc        = CL_OK;
+    SaAisErrorT       rc1       = SA_AIS_OK;
     ClSvcHandleT      svcHandle = {0};
     ClEoExecutionObjT *eoObj    = NULL ;
     //ClOsalTaskIdT     taskId    = 0;
 
+    
+    version.releaseCode  = 'B';
+    version.majorVersion = 0x01;
+    version.minorVersion = 0x01;
+    
+    callbacks.saAmfHealthcheckCallback          = NULL; 
+    callbacks.saAmfComponentTerminateCallback   = nameSvcFinalize;
+    callbacks.saAmfCSISetCallback               = NULL;
+    callbacks.saAmfCSIRemoveCallback            = NULL;
+    callbacks.saAmfProtectionGroupTrackCallback = NULL;
+    callbacks.saAmfProxiedComponentInstantiateCallback = NULL;
+    callbacks.saAmfProxiedComponentCleanupCallback = NULL;
+
+   
+    (void)clEoMyEoObjectGet(&eoObj);
+    (void)clEoMyEoIocPortGet(&iocPort);
+    rc1 = saAmfInitialize(&amfHandle, &callbacks, &version);
+    if( SA_AIS_OK != rc1 )
+    {
+        rc = rc1;
+        return rc;
+    }
     /* NS Initialize */
     rc = clCpmMasterAddressGet(&gMasterAddress);
     if (rc != CL_OK)
@@ -247,24 +284,9 @@ ClRcT   nameSvcInitialize(ClUint32T argc, ClCharT *argv[])
     }
     clNameCompCfg();
 
-   /*  Do the CPM client init/Register */
-    version.releaseCode = 'B';
-    version.majorVersion = 0x01;
-    version.minorVersion = 0x01;
-    
-    callbacks.appHealthCheck = NULL;
-    callbacks.appTerminate = nameSvcFinalize;
-    callbacks.appCSISet = NULL;
-    callbacks.appCSIRmv = NULL;
-    callbacks.appProtectionGroupTrack = NULL;
-    callbacks.appProxiedComponentInstantiate = NULL;
-    callbacks.appProxiedComponentCleanup = NULL;
 
-   
-    (void)clEoMyEoObjectGet(&eoObj);
-    (void)clEoMyEoIocPortGet(&iocPort);
-    rc = clCpmClientInitialize(&cpmHandle, &callbacks, &version);
-    if( CL_OK != rc ) return rc;
+
+    cpmHandle = (ClCpmHandleT)amfHandle;
     svcHandle.cpmHandle = &cpmHandle;
 #if 0
     svcHandle.evtHandle = &evtHandle;
@@ -273,8 +295,8 @@ ClRcT   nameSvcInitialize(ClUint32T argc, ClCharT *argv[])
     svcHandle.dlsHandle = &dlsHandle;
     rc = clDispatchThreadCreate(eoObj, &taskId, svcHandle);
 #endif    
-    rc = clCpmComponentNameGet(cpmHandle, &appName);
-    rc = clCpmComponentRegister(cpmHandle, &appName, NULL);
+     saAmfComponentNameGet(amfHandle, &appName);
+     saAmfComponentRegister(amfHandle, &appName, NULL);
     /*clDebugCli("NAME-CLI");*/
     return CL_OK;
 }
@@ -5491,8 +5513,8 @@ ClEoConfigT clEoConfig = {
     CL_IOC_NAME_PORT,
     CL_EO_USER_CLIENT_ID_START,
     CL_EO_USE_THREAD_FOR_RECV,
-    nameSvcInitialize,
-    clNameFinalize,
+    NULL,
+    NULL,
     nameSvcStateChange,
     nameSvcHealthCheck,
     NULL
@@ -5527,13 +5549,84 @@ ClUint8T clEoClientLibs[] = {
     CL_FALSE,    		/* pm */
 };
 
+void dispatchLoop(void);
+int  errorExit(SaAisErrorT rc);
+
+
 ClInt32T main(ClInt32T argc, ClCharT *argv[])
 {
     ClRcT rc = CL_OK;
 
     clAppConfigure(&clEoConfig,clEoBasicLibs,clEoClientLibs);
-    rc = clEoInitialize(argc, argv);
 
-    return (CL_OK != rc);
+
+    rc = nameSvcInitialize(argc,argv);
+    
+    if(rc != CL_OK)
+    {
+       CL_DEBUG_PRINT(CL_DEBUG_CRITICAL,
+                       ("Name: nameSvcInitialize failed [0x%X]\n\r", rc));
+        return rc;
+    }
+    
+    dispatchLoop();
+
+       
+    saAmfFinalize(amfHandle);
+
+    
+       
+
+    return 0;
+}
+
+
+
+
+
+
+int errorExit(SaAisErrorT rc)
+{        
+    
+    exit(-1);
+    return -1;
+}
+
+
+void dispatchLoop(void)
+{        
+  SaAisErrorT         rc = SA_AIS_OK;
+  SaSelectionObjectT amf_dispatch_fd;
+  int maxFd;
+  fd_set read_fds;
+
+  /*
+   * Get the AMF dispatch FD for the callbacks
+   */
+  if ( (rc = saAmfSelectionObjectGet(amfHandle, &amf_dispatch_fd)) != SA_AIS_OK)
+    errorExit(rc);
+  
+    
+  maxFd = amf_dispatch_fd;  
+  do
+    {
+      FD_ZERO(&read_fds);
+      FD_SET(amf_dispatch_fd, &read_fds);
+      
+        
+      if( select(maxFd + 1, &read_fds, NULL, NULL, NULL) < 0)
+        {
+          char errorStr[80];
+          int err = errno;
+          if (EINTR == err) continue;
+
+          errorStr[0] = 0; /* just in case strerror does not fill it in */
+          strerror_r(err, errorStr, 79);
+         
+          break;
+        }
+      if (FD_ISSET(amf_dispatch_fd,&read_fds)) saAmfDispatch(amfHandle, SA_DISPATCH_ALL);
+      
+    }while(!unblockNow);      
 }
 


### PR DESCRIPTION
Most SAFplus services use an "old style" startup that calls clEoInitialize(ClInt32T argc, ClCharT *argv[]) and has a trivial (or no) main function. Instead the real application "main" is passed as a callback.

This should be converted to a more standard application, with a real "main" function and no callback. saAmfInitialize() (preferred) or clASPInitialize should instead be called to start the basic SAFplus functions.

And clASPInitialize should be renamed to clSAFplusInitialize() if saAmfInitialize cannot be used as the external API.

Made the Changes and fixed this Issue

Testing has been done using csa 101,102 ,103 ,104 ,112 and 113
