### PR TITLE
SAFplus services: Convert old "EO" initialization method to non-eo method

### DIFF
--- a/src/SAFplus/components/amf/client/cpm/clCpmClientExt.c
+++ b/src/SAFplus/components/amf/client/cpm/clCpmClientExt.c
@@ -42,7 +42,7 @@
 #include <clCpmApi.h>
 #include <clDebugApi.h>
 #include <clLogApi.h>
-
+#include <saAmf.h>
 /*
  * ASP internal header files
  */
@@ -1030,6 +1030,21 @@ ClRcT clCpmComponentIdGet(ClCpmHandleT cpmHandle,
                           ClUint32T *compId)
 {
     ClRcT rc = CL_OK;
+    SaNameT compName1;
+    compName1.length = compName->length; 
+    memcpy(compName1.value,compName->value,compName->length+1);
+    rc=clAmfGetComponentId(cpmHandle,&compName1,compId);
+    
+    return rc;
+
+
+}
+
+ClRcT clAmfGetComponentId(ClCpmHandleT cpmHandle,
+                          SaNameT *compName,
+                          ClUint32T *compId)
+{
+    ClRcT rc = CL_OK;
     ClUint32T bufSize = 0;
     static ClUint32T compIdSpace;
 
@@ -1043,12 +1058,12 @@ ClRcT clCpmComponentIdGet(ClCpmHandleT cpmHandle,
 
     bufSize = sizeof(compId);
     rc = clCpmClientRMDSyncNew(clIocLocalAddressGet(), CPM_COMPONENT_ID_GET,
-                               (ClUint8T *) compName, sizeof(ClNameT),
+                               (ClUint8T *) compName, sizeof(SaNameT),
                                (ClUint8T *) compId, &bufSize,
                                CL_RMD_CALL_NEED_REPLY, 0, 0, 0,
                                clXdrMarshallClNameT,
                                clXdrUnmarshallClUint32T);
-    if (rc != CL_OK)
+   if (rc != CL_OK)
     {
         rc = CL_OK;
         *compId = (clIocLocalAddressGet() << CL_CPM_IOC_SLOT_BITS) + compIdSpace;
@@ -1058,6 +1073,8 @@ ClRcT clCpmComponentIdGet(ClCpmHandleT cpmHandle,
   failure:
     return rc;
 }
+
+
 
 ClRcT clCpmComponentStatusGet(ClNameT *compName,
                               ClNameT *nodeName,

--- a/src/SAFplus/components/amf/include/clCpmApi.h
+++ b/src/SAFplus/components/amf/include/clCpmApi.h
@@ -46,6 +46,7 @@ extern "C"
 #include <clIocApi.h>
 #include <clRmdApi.h>
 #include <clIocApiExt.h>
+#include <saAmf.h>
 
 #include <clCpmConfigApi.h>
 #include <clCpmErrors.h>
@@ -1156,7 +1157,9 @@ extern ClRcT clCpmProtectionGroupTrackStop(CL_IN ClCpmHandleT cpmHandle,
 extern ClRcT clCpmComponentIdGet(CL_IN ClCpmHandleT cpmHandle,
                                  CL_IN ClNameT *pCompName,
                                  CL_OUT ClUint32T *pCompId);
-
+extern ClRcT clAmfGetComponentId(CL_IN ClCpmHandleT cpmHandle,
+                                 CL_IN SaNameT *pCompName,
+                                 CL_OUT ClUint32T *pCompId);
 /**
  ************************************
  *  \brief Returns the IOC address of a component.

--- a/src/SAFplus/components/ckpt/server/clCkptImport.c
+++ b/src/SAFplus/components/ckpt/server/clCkptImport.c
@@ -146,8 +146,8 @@ clCkptMasterAddressUpdate(ClIocNodeAddressT  leader,
         }
         else
         {
-            clCpmComponentNameGet(gCkptSvr->cpmHdl, &name);
-            clCpmComponentIdGet(gCkptSvr->cpmHdl, &name, 
+            clCpmComponentNameGet(gCkptSvr->amfHdl, &name);
+            clCpmComponentIdGet(gCkptSvr->amfHdl, &name, 
                                 &gCkptSvr->compId);
             gCkptSvr->masterInfo.compId = gCkptSvr->compId;
         }
@@ -371,8 +371,8 @@ ClRcT clCkptMasterAddressesSet()
         ClUint32T    compId = 0; 
         ClNameT      name   = {0};
  
-        clCpmComponentNameGet(gCkptSvr->cpmHdl, &name);
-        clCpmComponentIdGet(gCkptSvr->cpmHdl, &name, &compId);
+        clCpmComponentNameGet(gCkptSvr->amfHdl, &name);
+        clCpmComponentIdGet(gCkptSvr->amfHdl, &name, &compId);
         tlInfo.compId                   = compId;
         gCkptSvr->masterInfo.compId     = compId;
         ckptOwnLogicalAddressGet(&tlInfo.logicalAddr);

--- a/src/SAFplus/components/ckpt/server/clCkptLife.c
+++ b/src/SAFplus/components/ckpt/server/clCkptLife.c
@@ -142,7 +142,7 @@ ClRcT clCkptSvrInitialize(void)
          * The node coming up is master. If deputy exists, syncup with deputy
          * else syncup with persistant memory (if existing).
          */
-        rc = clCpmComponentNameGet(gCkptSvr->cpmHdl, &appName);
+        rc = clCpmComponentNameGet(gCkptSvr->amfHdl, &appName);
         if(clCpmIsCompRestarted(appName))
         {
             if((deputy != CL_CKPT_UNINIT_ADDR) 

--- a/src/SAFplus/components/ckpt/server/clCkptSvr.h
+++ b/src/SAFplus/components/ckpt/server/clCkptSvr.h
@@ -123,7 +123,7 @@ typedef struct ckptSvrCb
     ClEoExecutionObjT      *eoHdl;       /* EO handle for al EO related
                                             operations */
     ClIocPortT             eoPort;       /* EO port */
-    ClCpmHandleT           cpmHdl;       /* CPM handle */
+    ClCpmHandleT           amfHdl;       /* CPM handle */
     ClGmsHandleT           gmsHdl;       /* GMS handle */
     ClEventInitHandleT     evtSvcHdl;    /* Event Service Handle */
     ClEventChannelHandleT  evtChHdl;     /* Event Channel handle */


### PR DESCRIPTION
Most SAFplus services use an "old style" startup that calls clEoInitialize (ClInt32T argc, ClCharT *argv []) and has a trivial (or no) main function. Instead the real application "main" is passed as a callback.

This should be converted to a more standard application, with a real "main" function and no call back. saAmfInitialize () (preferred) or clASPInitialize should instead be called to start the basic SAFplus functions.

 The following process and node kill were done during testing
1. Killed one of  the SAF services (like Name or Event ) that particular service restarted
2. Killed one of the critical SAF services (like sport , MSG and GMs ) entire node    restarted
3. killed active controller, then standby controller becomes active for providing services    to worker node
4. Tested with csa101, 102,103,104,112 and 113 examples
