### PR TITLE
fix no interaction install dir variable

### DIFF
--- a/install.py
+++ b/install.py
@@ -646,7 +646,7 @@ class ASPInstaller:
             self.print_install_header()
 
             if self.NO_INTERACTION == True:
-                strin = INSTALL_DIR
+                strin = self.INSTALL_DIR
             else:
                 strin = self.get_user_feedback('Enter the installation root directory [default: %s]: ' % self.INSTALL_DIR)
 


### PR DESCRIPTION
This fixes the command './install --no-interaction --install-dir /tmp/oc'
